### PR TITLE
[CI]: Ensure phpstan / ci passes

### DIFF
--- a/src/Promise.php
+++ b/src/Promise.php
@@ -7,14 +7,14 @@ namespace Pokio;
 use Closure;
 use Pokio\Contracts\Result;
 
-final readonly class Promise
+final class Promise
 {
     private Result $result;
 
     /**
      * Creates a new promise instance.
      */
-    public function __construct(private Closure $callback)
+    public function __construct(private readonly Closure $callback)
     {
         //
     }

--- a/src/Runtime/Fork/ForkResult.php
+++ b/src/Runtime/Fork/ForkResult.php
@@ -3,6 +3,7 @@
 namespace Pokio\Runtime\Fork;
 
 use Pokio\Contracts\Result;
+use RuntimeException;
 
 /**
  * Represents the result of a forked process.
@@ -39,8 +40,12 @@ final class ForkResult implements Result
 
         $pipe = fopen($this->pipePath, 'r');
 
+        if ($pipe === false) {
+            throw new RuntimeException('Failed to open pipe (reading)');
+        }
+
         stream_set_blocking($pipe, true);
-        $serialized = stream_get_contents($pipe);
+        $serialized = (string) stream_get_contents($pipe);
         fclose($pipe);
 
         if (file_exists($this->pipePath)) {

--- a/src/Runtime/Fork/ForkRuntime.php
+++ b/src/Runtime/Fork/ForkRuntime.php
@@ -37,6 +37,10 @@ final readonly class ForkRuntime implements Runtime
             $result = $callback();
             $pipe = fopen($pipePath, 'w');
 
+            if ($pipe === false) {
+                throw new RuntimeException('Failed to open pipe (writing)');
+            }
+
             fwrite($pipe, serialize($result));
             fclose($pipe);
 


### PR DESCRIPTION
This is a simple pull request, fixing the existing problems with phpstan to ensure the CI passes.

**There where two major changes:**
1. Promise can't be readonly, as the result is assigned in a function, not the constructor
2. The file functions (`fopen`etc.) require a resource, and the variable could have been `false`