### PR TITLE
Feature/encrypted serialization

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -10,7 +10,10 @@
         }
     ],
     "require": {
-        "php": "^8.3.0"
+        "php": "^8.3.0",
+        "ext-openssl": "*",
+        "ext-pcntl": "*",
+        "ext-posix": "*"
     },
     "require-dev": {
         "laravel/pint": "^1.22.1",

--- a/src/Runtime/Fork/ForkResult.php
+++ b/src/Runtime/Fork/ForkResult.php
@@ -3,6 +3,7 @@
 namespace Pokio\Runtime\Fork;
 
 use Pokio\Contracts\Result;
+use Pokio\Support\Encryption;
 
 /**
  * Represents the result of a forked process.
@@ -40,7 +41,7 @@ final class ForkResult implements Result
         $pipe = fopen($this->pipePath, 'r');
 
         stream_set_blocking($pipe, true);
-        $serialized = stream_get_contents($pipe);
+        $encryptedData = stream_get_contents($pipe);
         fclose($pipe);
 
         if (file_exists($this->pipePath)) {
@@ -48,6 +49,9 @@ final class ForkResult implements Result
         }
 
         $this->resolved = true;
+
+        // Decrypt the data before unserializing
+        $serialized = Encryption::decrypt($encryptedData);
 
         return $this->result = unserialize($serialized);
     }

--- a/src/Runtime/Fork/ForkRuntime.php
+++ b/src/Runtime/Fork/ForkRuntime.php
@@ -7,6 +7,7 @@ namespace Pokio\Runtime\Fork;
 use Closure;
 use Pokio\Contracts\Result;
 use Pokio\Contracts\Runtime;
+use Pokio\Support\Encryption;
 use Pokio\Support\PipePath;
 use RuntimeException;
 
@@ -37,7 +38,10 @@ final readonly class ForkRuntime implements Runtime
             $result = $callback();
             $pipe = fopen($pipePath, 'w');
 
-            fwrite($pipe, serialize($result));
+            $serialized = serialize($result);
+            $encrypted = Encryption::encrypt($serialized);
+
+            fwrite($pipe, $encrypted);
             fclose($pipe);
 
             exit(0);

--- a/src/Support/Encryption.php
+++ b/src/Support/Encryption.php
@@ -1,0 +1,243 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Pokio\Support;
+
+use RuntimeException;
+
+/**
+ * An encryption/decryption utility for Pokio.
+ */
+final class Encryption
+{
+    /**
+     * The encryption method used.
+     */
+    private const string CIPHER_METHOD = 'aes-256-gcm';
+
+    /**
+     * Authentication tag length.
+     */
+    private const int TAG_LENGTH = 16;
+
+    /**
+     * Environment variable for the encryption key.
+     */
+    private const string ENV_KEY = 'POKIO_ENCRYPTION_KEY';
+
+    /**
+     * Encrypts the given data.
+     *
+     * @throws RuntimeException If encryption fails.
+     */
+    public static function encrypt(string $data, ?string $key = null): string
+    {
+        $key ??= self::getEncryptionKey();
+        $ivlen = openssl_cipher_iv_length(self::CIPHER_METHOD);
+
+        if (function_exists('random_bytes')) {
+            $iv = random_bytes($ivlen);
+        } elseif (function_exists('openssl_random_pseudo_bytes')) {
+            $iv = openssl_random_pseudo_bytes($ivlen, $strong);
+            if (! $strong) {
+                throw new RuntimeException('Failed to generate secure IV');
+            }
+        } else {
+            throw new RuntimeException('No source of secure random available');
+        }
+
+        $tag = '';
+
+        $encrypted = openssl_encrypt(
+            $data,
+            self::CIPHER_METHOD,
+            $key,
+            OPENSSL_RAW_DATA,
+            $iv,
+            $tag,
+            '',
+            self::TAG_LENGTH
+        );
+
+        if ($encrypted === false) {
+            throw new RuntimeException('Encryption failed: '.openssl_error_string());
+        }
+
+        $result = [
+            'iv' => base64_encode($iv),
+            'tag' => base64_encode($tag),
+            'data' => base64_encode($encrypted),
+        ];
+
+        return base64_encode(json_encode($result));
+    }
+
+    /**
+     * Decrypts the given data.
+     *
+     * @throws RuntimeException If decryption fails or the data is invalid.
+     */
+    public static function decrypt(string $data, ?string $key = null): string
+    {
+        $key ??= self::getEncryptionKey();
+
+        try {
+            $decoded = base64_decode($data, true);
+            if ($decoded === false) {
+                throw new RuntimeException('Invalid base64 encoded data');
+            }
+
+            $parts = json_decode($decoded, true);
+            if (json_last_error() !== JSON_ERROR_NONE) {
+                throw new RuntimeException('Invalid encrypted data format');
+            }
+
+            if (! isset($parts['iv'], $parts['tag'], $parts['data'])) {
+                throw new RuntimeException('Missing required encryption components');
+            }
+
+            $iv = base64_decode((string) $parts['iv'], true);
+            $tag = base64_decode((string) $parts['tag'], true);
+            $encrypted = base64_decode((string) $parts['data'], true);
+
+            if ($iv === false || $tag === false || $encrypted === false) {
+                throw new RuntimeException('Invalid encryption components');
+            }
+
+            $decrypted = openssl_decrypt(
+                $encrypted,
+                self::CIPHER_METHOD,
+                $key,
+                OPENSSL_RAW_DATA,
+                $iv,
+                $tag,
+                ''
+            );
+
+            if ($decrypted === false) {
+                throw new RuntimeException('Decryption failed: '.openssl_error_string());
+            }
+
+            return $decrypted;
+        } catch (RuntimeException $e) {
+            throw $e;
+        } catch (\Throwable $e) {
+            throw new RuntimeException('Decryption error: '.$e->getMessage(), 0, $e);
+        }
+    }
+
+    /**
+     * Gets the encryption key from environment or generates a secure one.
+     *
+     * @throws RuntimeException If key requirements aren't met.
+     */
+    public static function getEncryptionKey(): string
+    {
+
+        $envKey = getenv(self::ENV_KEY);
+
+        if ($envKey !== false && strlen($envKey) >= 32) {
+
+            return hash('sha256', $envKey, true);
+        }
+
+        $keyFile = self::getKeyFilePath();
+        if (file_exists($keyFile)) {
+            $fileKey = trim(file_get_contents($keyFile));
+            if (strlen($fileKey) >= 32) {
+                return hash('sha256', $fileKey, true);
+            }
+        }
+
+        if (getenv('POKIO_AUTO_GENERATE_KEY') === 'true') {
+            return self::generateAndPersistKey();
+        }
+
+        trigger_error(
+            'No secure encryption key available. Set POKIO_ENCRYPTION_KEY environment variable'.
+            ' or allow auto-generation with POKIO_AUTO_GENERATE_KEY=true',
+            E_USER_WARNING
+        );
+
+        return hash('sha256', sys_get_temp_dir().get_current_user().__DIR__, true);
+    }
+
+    /**
+     * Generates a secure key and persists it if possible.
+     */
+    private static function generateAndPersistKey(): string
+    {
+
+        $randomBytes = function_exists('random_bytes')
+            ? random_bytes(32)
+            : openssl_random_pseudo_bytes(32);
+
+        $rawKey = bin2hex($randomBytes);
+
+        $keyFile = self::getKeyFilePath();
+        $directory = dirname($keyFile);
+
+        if (! is_dir($directory) && is_writable(dirname($directory))) {
+            mkdir($directory, 0700, true);
+        }
+
+        if (is_dir($directory) && is_writable($directory)) {
+            file_put_contents($keyFile, $rawKey);
+            chmod($keyFile, 0600);
+        }
+
+        return hash('sha256', $rawKey, true);
+    }
+
+    /**
+     * Gets the path to the key file.
+     */
+    private static function getKeyFilePath(): string
+    {
+        $configPath = getenv('POKIO_CONFIG_PATH');
+        $basePath = $configPath !== false
+            ? $configPath
+            : (sys_get_temp_dir().DIRECTORY_SEPARATOR.'pokio');
+
+        return $basePath.DIRECTORY_SEPARATOR.'.encryption_key';
+    }
+
+    /**
+     * Verifies the current encryption setup.
+     *
+     * @return array<string, mixed> Status information
+     */
+    public static function validateSetup(): array
+    {
+        $status = [
+            'cipher_supported' => in_array(self::CIPHER_METHOD, openssl_get_cipher_methods()),
+            'key_source' => 'fallback',
+            'key_length' => 0,
+            'security_level' => 'low',
+        ];
+
+        $envKey = getenv(self::ENV_KEY);
+        if ($envKey !== false && strlen($envKey) >= 32) {
+            $status['key_source'] = 'environment';
+            $status['key_length'] = strlen($envKey);
+            $status['security_level'] = 'high';
+        }
+
+        $keyFile = self::getKeyFilePath();
+        if (file_exists($keyFile)) {
+            $fileKey = trim(file_get_contents($keyFile));
+            $status['key_file_exists'] = true;
+            $status['key_file_permissions'] = substr(sprintf('%o', fileperms($keyFile)), -4);
+            $status['key_file_secure'] = (fileperms($keyFile) & 0177) === 0;
+
+            if (strlen($fileKey) >= 32 && $status['key_source'] === 'fallback') {
+                $status['key_source'] = 'file';
+                $status['key_length'] = strlen($fileKey);
+                $status['security_level'] = $status['key_file_secure'] ? 'medium' : 'low';
+            }
+        }
+
+        return $status;
+    }
+}

--- a/tests/Unit/EncryptionTest.php
+++ b/tests/Unit/EncryptionTest.php
@@ -1,0 +1,33 @@
+<?php
+
+use Pokio\Support\Encryption;
+
+test('encryption and decryption works correctly', function (): void {
+    $originalData = 'Hello, world!';
+
+    $encrypted = Encryption::encrypt($originalData);
+    expect($encrypted)->not->toBe($originalData);
+
+    $decrypted = Encryption::decrypt($encrypted);
+    expect($decrypted)->toBe($originalData);
+});
+
+test('encryption with custom key works correctly', function (): void {
+    $originalData = 'Secret message';
+    $customKey = 'my-custom-key-for-testing';
+
+    $encrypted = Encryption::encrypt($originalData, $customKey);
+    $decrypted = Encryption::decrypt($encrypted, $customKey);
+
+    expect($decrypted)->toBe($originalData);
+});
+
+test('decryption fails with incorrect key', function (): void {
+    $originalData = 'Secret message';
+    $correctKey = 'correct-key';
+    $incorrectKey = 'incorrect-key';
+
+    $encrypted = Encryption::encrypt($originalData, $correctKey);
+    $decrypted = Encryption::decrypt($encrypted, $incorrectKey);
+    expect($decrypted)->not->toBe($originalData);
+});

--- a/tests/Unit/Runtime/Fork/ForkRuntimeEncryptionTest.php
+++ b/tests/Unit/Runtime/Fork/ForkRuntimeEncryptionTest.php
@@ -1,0 +1,25 @@
+<?php
+
+test('fork runtime with encryption works correctly', function (): void {
+    // Only run this test when the fork runtime is active and the required extensions are available
+    if (! extension_loaded('pcntl') || ! extension_loaded('posix')) {
+        $this->markTestSkipped('pcntl and posix extensions are required for this test');
+    }
+
+    // Force the fork runtime
+    \Pokio\Environment::useFork();
+
+    // Test with a complex data structure to ensure serialization works correctly
+    $complexData = [
+        'string' => 'Hello, world!',
+        'number' => 42,
+        'boolean' => true,
+        'array' => [1, 2, 3],
+        'object' => (object) ['foo' => 'bar'],
+    ];
+
+    $promise = async(fn (): array => $complexData);
+    $result = await($promise);
+
+    expect($result)->toBe($complexData);
+});


### PR DESCRIPTION
# Add Encryption for Serialized Data

Implements the TODO from README.md to encrypt serialized data in the ForkRuntime.

## Key Changes
- New `Encryption` utility class using AES-256-GCM with authentication
- Modified ForkRuntime and ForkResult to encrypt/decrypt data during IPC
- Added environment variable support: `POKIO_ENCRYPTION_KEY`, `POKIO_AUTO_GENERATE_KEY`, `POKIO_CONFIG_PATH`
- Includes comprehensive error handling and secure key management
No breaking changes - maintains compatibility with existing API.