### PR TITLE
[Encryption]: Add basic encryption

### DIFF
--- a/src/Environment.php
+++ b/src/Environment.php
@@ -16,6 +16,11 @@ final class Environment
     public static ?Runtime $runtime = null;
 
     /**
+     * The environment's encryption key.
+     */
+    private static ?string $encryptionKey = null;
+
+    /**
      * The environment's runtime.
      */
     public static function useFork(): void
@@ -45,5 +50,22 @@ final class Environment
         return self::$runtime ??= $areExtensionsAvailable
             ? new ForkRuntime
             : new SyncRuntime;
+    }
+
+    /**
+     * Sets the environment's encryption key.
+     * Hashes the given key using SHA-256 to ensure a 32-byte key for encryption.
+     */
+    public static function setEncryptionKey(string $key): void
+    {
+        self::$encryptionKey = hash('sha256', $key, false);
+    }
+
+    /**
+     * Gets the environment's encryption key.
+     */
+    public static function getEncryptionKey(): ?string
+    {
+        return self::$encryptionKey;
     }
 }


### PR DESCRIPTION
## Description

This pull requests aims to add a basic level of encrpytion to the serialization and deserialization!
I though of this API over an ENV_Var to allow the user to decide, where and how they want to store, name the key etc:

```php
 Environment::setEncryptionKey('my-secret-key');
```

Therefore the user can by default also choose not to have any encryption, or different encryptions for different parts of the application where this plugin might be used.

> [!IMPORTANT]  
> Whilst working on this feature I saw #7 which uses a similar implementation (more elaborate) with tests etc. I didn't full check it but I stopped here to see what @nunomaduro thinks, before proceeding to expand this implementation. I also didn't fully test this implementation, if it would work in this way.


## Related / Duplicates

- #7 