### PR TITLE
[Feature]: Add Pokio facade with spawn and join support

### DIFF
--- a/src/Support/JoinHandle.php
+++ b/src/Support/JoinHandle.php
@@ -1,0 +1,32 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Pokio\Support;
+
+use Pokio\Promise;
+
+final readonly class JoinHandle
+{
+    public function __construct(
+        private Promise $promise
+    ) {
+        //
+    }
+
+    /**
+     * Awaits the resolution of the task.
+     */
+    public function await(): mixed
+    {
+        return await($this->promise);
+    }
+    
+    /**
+     * Gets the raw promise, if needed.
+     */
+    public function promise(): Promise
+    {
+        return $this->promise;
+    }
+}

--- a/src/Support/Pokio.php
+++ b/src/Support/Pokio.php
@@ -1,0 +1,24 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Pokio\Support;
+
+use Closure;
+
+final class Pokio
+{
+    public static function spawn(Closure $callback): JoinHandle
+    {
+        return new JoinHandle(async($callback));
+    }
+
+    public static function join(array|JoinHandle $handles): mixed
+    {
+        if (! is_array($handles)) {
+            return $handles->await();
+        }
+
+        return array_map(fn(JoinHandle $handle): mixed => $handle->await(), $handles);
+    }
+}

--- a/tests/Unit/Support/JoinHandle.php
+++ b/tests/Unit/Support/JoinHandle.php
@@ -1,0 +1,16 @@
+<?php
+
+use Pokio\Support\JoinHandle;
+
+test('await returns the resolved result', function () {
+    $handle = new JoinHandle(async(fn() => 42));
+
+    expect($handle->await())->toBe(42);
+});
+
+test('promise method returns the raw promise', function () {
+    $promise = async(fn() => 123);
+    $handle = new JoinHandle($promise);
+
+    expect($handle->promise())->toBe($promise);
+});

--- a/tests/Unit/Support/PokioTest.php
+++ b/tests/Unit/Support/PokioTest.php
@@ -1,0 +1,21 @@
+<?php
+
+use Pokio\Support\Pokio;
+
+test('spawn with a single task', function (): void {
+    $handle = Pokio::spawn(fn(): int => 1 + 2);
+
+    $result = $handle->await();
+
+    expect($result)->toBe(3);
+});
+
+test('spawn with multiple tasks and join results', function (): void {
+    $handleA = Pokio::spawn(fn(): int => 1 + 2);
+    $handleB = Pokio::spawn(fn(): int => 3 + 4);
+
+    [$resultA, $resultB] = Pokio::join([$handleA, $handleB]);
+
+    expect($resultA)->toBe(3)
+        ->and($resultB)->toBe(7);
+});


### PR DESCRIPTION
## Add Pokio facade with spawn and join

This PR introduces the `Pokio\Support\Pokio` class and the `JoinHandle` abstraction.

The main goal is to provide a syntax that closely resembles Rust’s Tokio and to open the class to future extensions such as `sleep()`, `timeout()`, `select()`, and more.

This structure also prepares the foundation for advanced Tokio-like features such as channels, task cancellation, and cooperative multitasking.

### Added

- `Pokio::spawn(Closure $callback): JoinHandle`
- `Pokio::join(array<JoinHandle>|JoinHandle $handles): array|mixed`

---

### Example

#### PHP (Pokio)

```php
$h1 = Pokio::spawn(fn () => 10);
$h2 = Pokio::spawn(fn () => 32);

[$a, $b] = Pokio::join([$h1, $h2]);
```
#### Rust (Tokio)
```rust
let h1 = tokio::spawn(async { 10 });
let h2 = tokio::spawn(async { 32 });

let (a, b) = tokio::join!(h1, h2);
```