### PR TITLE
Refactor api and add `->then()`, `->finally()`, `->catch()`

### DIFF
--- a/src/Contracts/Runtime.php
+++ b/src/Contracts/Runtime.php
@@ -11,5 +11,5 @@ interface Runtime
     /**
      * Defers the given callback to be executed asynchronously.
      */
-    public function defer(Closure $callback, ?Closure $rescue = null): Result;
+    public function defer(Closure $callback): Result;
 }

--- a/src/Functions.php
+++ b/src/Functions.php
@@ -13,9 +13,9 @@ if (! function_exists('async')) {
      * @param  Closure(): TReturn  $callback
      * @return Promise<TReturn>
      */
-    function async(Closure $callback, ?Closure $rescue = null): Promise
+    function async(Closure $callback): Promise
     {
-        $promise = new Promise($callback, $rescue);
+        $promise = new Promise($callback);
 
         $promise->run();
 

--- a/src/Runtime/Fork/ForkRuntime.php
+++ b/src/Runtime/Fork/ForkRuntime.php
@@ -17,7 +17,7 @@ final readonly class ForkRuntime implements Runtime
     /**
      * Defers the given callback to be executed asynchronously.
      */
-    public function defer(Closure $callback, ?Closure $rescue = null): Result
+    public function defer(Closure $callback): Result
     {
         // random 27-bit positive key
         $shmKey = random_int(0x100000, 0x7FFFFFFF);
@@ -37,10 +37,6 @@ final readonly class ForkRuntime implements Runtime
                 }
             } catch (Throwable $exception) {
                 $result = new PokioExceptionHandler($exception);
-
-                if ($rescue instanceof Closure) {
-                    $result = $rescue($exception);
-                }
             }
 
             $data = serialize($result);

--- a/src/Runtime/Sync/SyncResult.php
+++ b/src/Runtime/Sync/SyncResult.php
@@ -14,7 +14,7 @@ final readonly class SyncResult implements Result
     /**
      * Creates a new sync result instance.
      */
-    public function __construct(private Closure $callback, private ?Closure $rescue = null)
+    public function __construct(private Closure $callback)
     {
         //
     }
@@ -24,20 +24,12 @@ final readonly class SyncResult implements Result
      */
     public function get(): mixed
     {
-        try {
-            $result = ($this->callback)();
+        $result = ($this->callback)();
 
-            if ($result instanceof Promise) {
-                return await($result);
-            }
-
-            return $result;
-        } catch (Throwable $exception) {
-            if ($this->rescue instanceof Closure) {
-                return ($this->rescue)($exception);
-            }
-
-            throw $exception;
+        if ($result instanceof Promise) {
+            return await($result);
         }
+
+        return $result;
     }
 }

--- a/src/Runtime/Sync/SyncResult.php
+++ b/src/Runtime/Sync/SyncResult.php
@@ -7,7 +7,6 @@ namespace Pokio\Runtime\Sync;
 use Closure;
 use Pokio\Contracts\Result;
 use Pokio\Promise;
-use Throwable;
 
 final readonly class SyncResult implements Result
 {

--- a/src/Runtime/Sync/SyncRuntime.php
+++ b/src/Runtime/Sync/SyncRuntime.php
@@ -13,8 +13,8 @@ final readonly class SyncRuntime implements Runtime
     /**
      * Defers the given callback to be executed asynchronously.
      */
-    public function defer(Closure $callback, ?Closure $rescue = null): Result
+    public function defer(Closure $callback): Result
     {
-        return new SyncResult($callback, $rescue);
+        return new SyncResult($callback);
     }
 }

--- a/tests/Datasets.php
+++ b/tests/Datasets.php
@@ -6,7 +6,7 @@ use Pokio\Environment;
 
 dataset('runtimes', [
     'sync' => fn () => Environment::useSync(),
-    'fork' => function () {
+    'fork' => function (): void {
         if (! extension_loaded('pcntl') || ! extension_loaded('posix')) {
             $this->markTestSkipped('The pcntl and posix extensions are required to use the fork runtime.');
         }

--- a/tests/Feature/AwaitTest.php
+++ b/tests/Feature/AwaitTest.php
@@ -20,3 +20,12 @@ test('async with a multiple promises', function (): void {
     expect($resultA)->toBe(3)
         ->and($resultB)->toBe(7);
 })->with('runtimes');
+
+test('async with a then', function (): void {
+    $promise = async(fn (): int => 1 + 2)
+        ->then(fn ($result): int => $result + 5);
+
+    $result = await($promise);
+
+    expect($result)->toBe(8);
+})->with('runtimes');

--- a/tests/Feature/ExceptionsTest.php
+++ b/tests/Feature/ExceptionsTest.php
@@ -17,12 +17,25 @@ test('async with an exception thrown', function (): void {
 test('async with a caught exception', function (): void {
     $promise = async(function (): void {
         throw new HedgehogException('Not enough hedgehogs');
-    }, function (Throwable $e): string {
+    })->catch(function (Throwable $e): string {
         expect($e)->toBeInstanceOf(HedgehogException::class)
             ->and($e->getMessage())->toEqual('Not enough hedgehogs');
 
         return 'Hedgehogs';
     });
+
+    $result = await($promise);
+
+    expect($result)->toEqual('Hedgehogs');
+})->with('runtimes');
+
+test('async with a caught exception with finally', function (): void {
+    $promise = async(function (): void {
+        throw new HedgehogException('Not enough hedgehogs');
+    })->catch(function (Throwable $e): string {
+        expect($e)->toBeInstanceOf(HedgehogException::class)
+            ->and($e->getMessage())->toEqual('Not enough hedgehogs');
+    })->finally(fn(): string => 'Hedgehogs');
 
     $result = await($promise);
 

--- a/tests/Feature/ExceptionsTest.php
+++ b/tests/Feature/ExceptionsTest.php
@@ -35,7 +35,7 @@ test('async with a caught exception with finally', function (): void {
     })->catch(function (Throwable $e): string {
         expect($e)->toBeInstanceOf(HedgehogException::class)
             ->and($e->getMessage())->toEqual('Not enough hedgehogs');
-    })->finally(fn(): string => 'Hedgehogs');
+    })->finally(fn (): string => 'Hedgehogs');
 
     $result = await($promise);
 

--- a/tests/Feature/RecursiveAwaitTest.php
+++ b/tests/Feature/RecursiveAwaitTest.php
@@ -2,8 +2,10 @@
 
 declare(strict_types=1);
 
+use Pokio\Promise;
+
 test('async with a recursive promise', function (): void {
-    $promise = async(fn () => async(fn () => async(fn () => async(fn () => async(fn () => 1)))));
+    $promise = async(fn (): Promise => async(fn (): Promise => async(fn (): Promise => async(fn (): Promise => async(fn (): int => 1)))));
 
     $result = await($promise);
 
@@ -11,8 +13,8 @@ test('async with a recursive promise', function (): void {
 })->with('runtimes');
 
 test('async with a recursive promise with multiple awaits', function (): void {
-    $promiseA = async(fn () => async(fn () => async(fn () => async(fn () => async(fn () => 1)))));
-    $promiseB = async(fn () => async(fn () => async(fn () => async(fn () => async(fn () => 2)))));
+    $promiseA = async(fn (): Promise => async(fn (): Promise => async(fn (): Promise => async(fn (): Promise => async(fn (): int => 1)))));
+    $promiseB = async(fn (): Promise => async(fn (): Promise => async(fn (): Promise => async(fn (): Promise => async(fn (): int => 2)))));
 
     [$resultA, $resultB] = await([$promiseA, $promiseB]);
 
@@ -21,9 +23,9 @@ test('async with a recursive promise with multiple awaits', function (): void {
 })->with('runtimes');
 
 test('async with a recursive promise with multiple awaits and a single await', function (): void {
-    $promise = async(fn () => async(fn () => async(function () {
-        $promiseA = async(fn () => async(fn () => async(fn () => async(fn () => async(fn () => 1)))));
-        $promiseB = async(fn () => async(fn () => async(fn () => async(fn () => async(fn () => 2)))));
+    $promise = async(fn (): Promise => async(fn (): Promise => async(function () {
+        $promiseA = async(fn (): Promise => async(fn (): Promise => async(fn (): Promise => async(fn (): Promise => async(fn (): int => 1)))));
+        $promiseB = async(fn (): Promise => async(fn (): Promise => async(fn (): Promise => async(fn (): Promise => async(fn (): int => 2)))));
 
         return await([$promiseA, $promiseB]);
     })));


### PR DESCRIPTION
I've updated the API to be able to chain `->then()`, `->finally()`, `->catch()`.

Then 
```
$promise = async(fn () => 1 + 1)
    ->then(fn ($result) => $result + 1);

var_dump(await($promise)) // int(3)
```

Catch
```
$promise = async(fn () =>  throw new HedgehogException('Not enough hedgehogs'))
    ->catch(function (Throwable $e) {
        report($e);
        
        return 'Cake';
    });

var_dump(await($promise)) // string("Cake")
```

Finally
```
$promise = async(fn () =>  throw new HedgehogException('Not enough hedgehogs'))
    ->catch(function (Throwable $e) {
        report($e);

        return 'Cake';
    })
    ->finally(fn () => 'Lemons');

var_dump(await($promise)) // string("Lemons") - finally will overwrite the return value

```

The only problem I see is the these method will be running on the main process. Maybe we could be clever and it to run in a child process and store the result before sending back to the main process. I'll look into this more.