### PR TITLE
[Promise API]: Add the `->then()` function within new promise

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ $promise = async(fn (): int => 1 + 2)
     ->then(fn ($result): int => $result * 2);
 
 $result = await($promise);
-var_dump($result); // int(8)
+var_dump($result); // int(10)
 ```
 
 Optionally, you may chain a `catch` method to the promise, which will be called if the given closure throws an exception.

--- a/README.md
+++ b/README.md
@@ -19,13 +19,13 @@
 ```php
 $promiseA = async(function () {
     sleep(2);
-    
+
     return 'Task 1';
 });
 
 $promiseB = async(function () {
     sleep(2);
-    
+
     return 'Task 2';
 });
 
@@ -50,7 +50,7 @@ composer require nunomaduro/pokio:@dev
 
 ## Usage
 
-- `async`
+-   `async`
 
 The `async` global function returns a promise that will eventually resolve the value returned by the given closure.
 
@@ -60,6 +60,17 @@ $promise = async(function () {
 });
 
 var_dump(await($promise)); // int(2)
+```
+
+Similar to other promise libraries, pokio allows you to chain methods to the promise. The `then` method will be called when the promise resolves.
+
+```php
+$promise = async(fn (): int => 1 + 2)
+    ->then(fn ($result): int => $result + 2)
+    ->then(fn ($result): int => $result * 2);
+
+$result = await($promise);
+var_dump($result); // int(8)
 ```
 
 Optionally, you may chain a `catch` method to the promise, which will be called if the given closure throws an exception.
@@ -100,14 +111,14 @@ $promise = async(function () {
 var_dump(await($promise)); // int(2)
 ```
 
-- `await`
+-   `await`
 
 The `await` global function will block the current process until the given promise resolves.
 
 ```php
 $promise = async(function () {
     sleep(2);
-    
+
     return 1 + 1;
 });
 
@@ -119,13 +130,13 @@ You may also pass an array of promises to the `await` function, which will be aw
 ```php
 $promiseA = async(function () {
     sleep(2);
-    
+
     return 1 + 1;
 });
 
 $promiseB = async(function () {
     sleep(2);
-    
+
     return 2 + 2;
 });
 
@@ -134,13 +145,13 @@ var_dump(await([$promiseA, $promiseB])); // array(2) { [0]=> int(2) [1]=> int(4)
 
 ## Follow Nuno
 
-- Follow the creator Nuno Maduro:
-    - YouTube: **[youtube.com/@nunomaduro](https://www.youtube.com/@nunomaduro)** — Videos every weekday
-    - Twitch: **[twitch.tv/enunomaduro](https://www.twitch.tv/enunomaduro)** — Streams (almost) every weekday
-    - Twitter / X: **[x.com/enunomaduro](https://x.com/enunomaduro)**
-    - LinkedIn: **[linkedin.com/in/nunomaduro](https://www.linkedin.com/in/nunomaduro)**
-    - Instagram: **[instagram.com/enunomaduro](https://www.instagram.com/enunomaduro)**
-    - Tiktok: **[tiktok.com/@enunomaduro](https://www.tiktok.com/@enunomaduro)**
+-   Follow the creator Nuno Maduro:
+    -   YouTube: **[youtube.com/@nunomaduro](https://www.youtube.com/@nunomaduro)** — Videos every weekday
+    -   Twitch: **[twitch.tv/enunomaduro](https://www.twitch.tv/enunomaduro)** — Streams (almost) every weekday
+    -   Twitter / X: **[x.com/enunomaduro](https://x.com/enunomaduro)**
+    -   LinkedIn: **[linkedin.com/in/nunomaduro](https://www.linkedin.com/in/nunomaduro)**
+    -   Instagram: **[instagram.com/enunomaduro](https://www.instagram.com/enunomaduro)**
+    -   Tiktok: **[tiktok.com/@enunomaduro](https://www.tiktok.com/@enunomaduro)**
 
 ## License
 

--- a/src/Promise.php
+++ b/src/Promise.php
@@ -40,4 +40,25 @@ final class Promise
     {
         return $this->result->get();
     }
+
+    /**
+     * Chains a callback to be executed after the promise resolves.
+     *
+     * @template TNextReturn
+     *
+     * @param  Closure(TReturn): TNextReturn  $onFulfilled
+     * @return Promise<TNextReturn>
+     */
+    public function then(Closure $onFulfilled): self
+    {
+        $promise = new self(function () use ($onFulfilled) {
+            $result = $this->resolve();
+
+            return $onFulfilled($result);
+        });
+
+        $promise->run();
+
+        return $promise;
+    }
 }

--- a/src/Promise.php
+++ b/src/Promise.php
@@ -53,6 +53,7 @@ final class Promise
     {
         return async(function () use ($onFulfilled) {
             $result = await($this);
+
             return $onFulfilled($result);
         });
     }

--- a/src/Promise.php
+++ b/src/Promise.php
@@ -51,14 +51,9 @@ final class Promise
      */
     public function then(Closure $onFulfilled): self
     {
-        $promise = new self(function () use ($onFulfilled) {
-            $result = $this->resolve();
-
+        return async(function () use ($onFulfilled) {
+            $result = await($this);
             return $onFulfilled($result);
         });
-
-        $promise->run();
-
-        return $promise;
     }
 }

--- a/tests/Datasets.php
+++ b/tests/Datasets.php
@@ -6,7 +6,7 @@ use Pokio\Environment;
 
 dataset('runtimes', [
     'sync' => fn () => Environment::useSync(),
-    'fork' => function () {
+    'fork' => function (): void {
         if (! extension_loaded('pcntl') || ! extension_loaded('posix')) {
             $this->markTestSkipped('The pcntl and posix extensions are required to use the fork runtime.');
         }

--- a/tests/Feature/AwaitTest.php
+++ b/tests/Feature/AwaitTest.php
@@ -20,3 +20,22 @@ test('async with a multiple promises', function (): void {
     expect($resultA)->toBe(3)
         ->and($resultB)->toBe(7);
 })->with('runtimes');
+
+test('async with a then', function (): void {
+    $promise = async(fn (): int => 1 + 2)
+        ->then(fn ($result): int => $result + 2);
+
+    $result = await($promise);
+
+    expect($result)->toBe(5);
+})->with('runtimes');
+
+test('async with multiple thens', function (): void {
+    $promise = async(fn (): int => 1 + 2)
+        ->then(fn ($result): int => $result + 2)
+        ->then(fn ($result): int => $result * 2);
+
+    $result = await($promise);
+
+    expect($result)->toBe(10);
+})->with('runtimes');


### PR DESCRIPTION
> [!IMPORTANT]  
> Something about this solution seems to cause problems with the shared memory beeing opened.
> I am unsure if this was just a local problem, or where this comes from...
>
> However, if we don't need a new promise for each then, the other pull request (#17) is probably better and safer!

## Description
This pull request addresses the suggested API Implementation similar to Javascript.

It provides a "chainable" implementation of the `->then()` function with full type support, tests and documentation.
```php
$promise = async(fn (): int => 1 + 2)
    ->then(fn ($result): int => $result + 2)
    ->then(fn ($result): int => $result * 2);

$result = await($promise);
var_dump($result); // int(10)
```

## Related
- #17 
- #12 