### PR TITLE
 [Promise API]: Add the `->then()`, `->catch()` and `->finally()` functions (Tests and Docs)

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,18 @@ $promise = async(function () {
 var_dump(await($promise)); // int(2)
 ```
 
+Similar to other promise libraries, Pokio allows you to chain methods to the promise (like `then`, `catch`, etc.).
+
+The `then` method will be called when the promise resolves successfully. It accepts a closure that will receive the resolved value as its first argument.
+
+```php
+$promise = async(fn (): int => 1 + 2)
+    ->then(fn ($result): int => $result + 2)
+    ->then(fn ($result): int => $result * 2);
+
+$result = await($promise);
+var_dump($result); // int(10)
+```
 Optionally, you may chain a `catch` method to the promise, which will be called if the given closure throws an exception.
 
 ```php
@@ -86,6 +98,16 @@ try {
 } catch (Throwable $e) {
     var_dump('Rescued: ' . $e->getMessage()); // string(16) "Rescued: Error"
 }
+```
+
+Similar to the `catch` method, you may also chain a `finally` method to the promise, which will be called regardless of whether the promise resolves successfully or throws an exception.
+
+```php
+$promise = async(function (): void {
+    throw new HedgehogException('Exception 1');
+})->finally(function () use (&$called): void {
+    echo "Finally called\n";
+});
 ```
 
 If you return a promise from the closure, it will be awaited automatically.

--- a/src/Promise.php
+++ b/src/Promise.php
@@ -6,6 +6,7 @@ namespace Pokio;
 
 use Closure;
 use Pokio\Contracts\Result;
+use Throwable;
 
 /**
  * @template TReturn
@@ -13,6 +14,23 @@ use Pokio\Contracts\Result;
 final class Promise
 {
     private Result $result;
+
+    /**
+     * A list of then callbacks.
+     *
+     * @var array<Closure(TReturn): TReturn>
+     */
+    private array $then = [];
+
+    /**
+     * @var Closure(Throwable): void|null
+     */
+    private ?Closure $catch = null;
+
+    /**
+     * @var Closure(): void|null
+     */
+    private ?Closure $finally = null;
 
     /**
      * Creates a new promise instance.
@@ -38,6 +56,67 @@ final class Promise
      */
     public function resolve(): mixed
     {
-        return $this->result->get();
+        $result = null;
+
+        try {
+            $result = $this->result->get();
+
+            foreach ($this->then as $then) {
+                $result = $then($result);
+            }
+
+            return $result;
+        } catch (Throwable $th) {
+            if ($this->catch !== null) {
+                ($this->catch)($th);
+
+                return $result;
+            }
+
+            throw $th;
+        } finally {
+            if ($this->finally !== null) {
+                ($this->finally)();
+            }
+        }
+    }
+
+    /**
+     * Adds a then callback to the promise.
+     *
+     * @param  Closure(TReturn): TReturn  $then
+     * @return Promise<TReturn>
+     */
+    public function then(Closure $then): self
+    {
+        $this->then[] = $then;
+
+        return $this;
+    }
+
+    /**
+     * Adds a catch callback to the promise.
+     *
+     * @param  Closure(Throwable): void  $catch
+     * @return Promise<TReturn>
+     */
+    public function catch(Closure $catch): self
+    {
+        $this->catch = $catch;
+
+        return $this;
+    }
+
+    /**
+     * Adds a finally callback to the promise.
+     *
+     * @param  Closure(): void  $finally
+     * @return Promise<TReturn>
+     */
+    public function finally(Closure $finally): self
+    {
+        $this->finally = $finally;
+
+        return $this;
     }
 }

--- a/tests/Datasets.php
+++ b/tests/Datasets.php
@@ -6,7 +6,7 @@ use Pokio\Environment;
 
 dataset('runtimes', [
     'sync' => fn () => Environment::useSync(),
-    'fork' => function () {
+    'fork' => function (): void {
         if (! extension_loaded('pcntl') || ! extension_loaded('posix')) {
             $this->markTestSkipped('The pcntl and posix extensions are required to use the fork runtime.');
         }

--- a/tests/Feature/AwaitTest.php
+++ b/tests/Feature/AwaitTest.php
@@ -60,7 +60,7 @@ test('async with a catch callback', function (): void {
 
 })->with('runtimes');
 
-test('async with a finally callback', function (): void {
+test('async with a finally callback called without exception', function (): void {
     $called = false;
 
     $promise = async(fn (): int => 1 + 2)
@@ -71,6 +71,22 @@ test('async with a finally callback', function (): void {
     $result = await($promise);
 
     expect($result)->toBe(3)->and($called)->toBeTrue();
+})->with('runtimes');
+
+test('async with a finally callback called with exception', function (): void {
+    $called = false;
+
+    $promise = async(function (): void {
+        throw new HedgehogException('Exception 1');
+    })->finally(function () use (&$called): void {
+        $called = true;
+    });
+
+    expect(function () use ($promise): void {
+        await($promise);
+    })->toThrow(HedgehogException::class, 'Exception 1');
+
+    expect($called)->toBeTrue();
 })->with('runtimes');
 
 test('async with a catch callback that throws an exception', function (): void {

--- a/tests/Feature/AwaitTest.php
+++ b/tests/Feature/AwaitTest.php
@@ -43,12 +43,21 @@ test('async with multiple then callbacks', function (): void {
 })->with('runtimes');
 
 test('async with a catch callback', function (): void {
-    $promise = async(fn (): int => 1 + 2)
-        ->catch(fn (Throwable $e): string => 'Caught: '.$e->getMessage());
+    $caught = false;
 
-    $result = await($promise);
+    $promise = async(function (): void {
+        throw new HedgehogException('Exception 1');
+    })->catch(function (Throwable $th) use (&$caught): void {
+        expect($th)->toBeInstanceOf(HedgehogException::class)
+            ->and($th->getMessage())->toBe('Exception 1');
 
-    expect($result)->toBe(3);
+        $caught = true;
+    });
+
+    await($promise);
+
+    expect($caught)->toBeTrue();
+
 })->with('runtimes');
 
 test('async with a finally callback', function (): void {


### PR DESCRIPTION
## Description

This pull request addresses the suggested API Implementation similar to Javascript (including tests and readme).

The implementation is **heavily inspired by #15** however I changed some things to ensure proper exception propagation and made the then function chainable.

It provides a "chainable" implementation of the `->then()` function with full type support, tests and documentation.
```php
$promise = async(fn (): int => 1 + 2)
    ->then(fn ($result): int => $result + 2)
    ->then(fn ($result): int => $result * 2);

$result = await($promise);
var_dump($result); // int(10)
```

Also there is a catch API:
```php
$promise = async(function (): void {
    throw new HedgehogException('Exception 1');
})->catch(function (Throwable $e): void { 
    echo "Caught!";
});
```

And a finally API:
```php
$called = false;

$promise = async(function (): void {
    throw new HedgehogException('Exception 1');
})->finally(function () use (&$called): void {
    $called = true;
});

echo $called; // true
```


## Related
- #15 
- #12 
- #11 
- #10 