### PR TITLE
[Test]: Add scope isolation tests

### DIFF
--- a/tests/Feature/ScopeIsolationTest.php
+++ b/tests/Feature/ScopeIsolationTest.php
@@ -2,7 +2,6 @@
 
 declare(strict_types=1);
 
-
 test('sync: global variables do leak into closure scope', function () {
     ensureSyncEnvironment();
 
@@ -19,6 +18,7 @@ test('sync: closure variables using `use` do leak outside', function () {
     $value = 'normal';
     $result = await(async(function () use (&$value) {
         $value = 'secret';
+
         return $value;
     }));
     expect($result)->toBe('secret')
@@ -76,6 +76,7 @@ test('fork: closure variables using `use` do not leak outside', function () {
     $value = 'normal';
     $result = await(async(function () use (&$value) {
         $value = 'secret';
+
         return $value;
     }));
 

--- a/tests/Feature/ScopeIsolationTest.php
+++ b/tests/Feature/ScopeIsolationTest.php
@@ -1,0 +1,119 @@
+<?php
+
+declare(strict_types=1);
+
+
+test('sync: global variables do leak into closure scope', function () {
+    ensureSyncEnvironment();
+
+    global $leakyGlobal;
+    $leakyGlobal = 'should not be visible';
+
+    $promise = async(fn () => isset($GLOBALS['leakyGlobal']));
+    expect(await($promise))->toBeTrue();
+});
+
+test('sync: closure variables using `use` do leak outside', function () {
+    ensureSyncEnvironment();
+
+    $value = 'normal';
+    $result = await(async(function () use (&$value) {
+        $value = 'secret';
+        return $value;
+    }));
+    expect($result)->toBe('secret')
+        ->and($value)->toBe('secret');
+});
+
+test('sync: constants are available inside closures', function () {
+    ensureSyncEnvironment();
+
+    define('SYNC_SCOPE_TEST_CONST', 'yes');
+    $result = await(async(fn () => constant('SYNC_SCOPE_TEST_CONST')));
+
+    expect($result)->toBe('yes');
+});
+
+test('sync: external variables are visible without `use`', function () {
+    ensureSyncEnvironment();
+
+    $secret = 'nope';
+
+    $promise = async(fn () => isset($secret));
+    expect(await($promise))->toBeTrue();
+});
+
+test('sync: callback does not persist GLOBALS in sync env', function (): void {
+    ensureSyncEnvironment();
+
+    $GLOBALS['test'] = 1;
+
+    $promise = async(function () {
+        $GLOBALS['test'] = 2;
+
+        return 1;
+    });
+
+    $result = await($promise);
+
+    expect($result)->toBe(1)
+        ->and($GLOBALS['test'])->toBe(2);
+});
+
+test('fork: global variables do leak into closure scope', function () {
+    ensureForkEnvironment();
+
+    global $leakyGlobal;
+    $leakyGlobal = 'should not be visible';
+
+    $promise = async(fn () => isset($GLOBALS['leakyGlobal']));
+    expect(await($promise))->toBeTrue();
+});
+
+test('fork: closure variables using `use` do not leak outside', function () {
+    ensureForkEnvironment();
+
+    $value = 'normal';
+    $result = await(async(function () use (&$value) {
+        $value = 'secret';
+        return $value;
+    }));
+
+    expect($result)->toBe('secret')
+        ->and($value)->toBe('normal');
+});
+
+test('fork: constants are available inside closures', function () {
+    ensureForkEnvironment();
+
+    define('FORK_SCOPE_TEST_CONST', 'yes');
+    $result = await(async(fn () => constant('FORK_SCOPE_TEST_CONST')));
+
+    expect($result)->toBe('yes');
+});
+
+test('fork: external variables are visible without `use`', function () {
+    ensureForkEnvironment();
+
+    $secret = 'nope';
+
+    $promise = async(fn () => isset($secret));
+    expect(await($promise))->toBeTrue();
+});
+
+test('fork: callback does not persist GLOBALS in fork env', function (): void {
+    ensureForkEnvironment();
+
+    $GLOBALS['test'] = 1;
+
+    $promise = async(function () {
+        $GLOBALS['test'] = 2;
+
+        return 1;
+    });
+
+    $result = await($promise);
+
+    expect($result)->toBe(1)
+        ->and($GLOBALS['test'])->toBe(1);
+});

--- a/tests/Pest.php
+++ b/tests/Pest.php
@@ -11,3 +11,28 @@ pest()->beforeEach(function (): void {
         default => null,
     };
 });
+
+if (! function_exists('ensureForkEnvironment')) {
+    /**
+     * Ensures the current environment is set to fork.
+     * Skips the test if the pcntl and posix extensions are not loaded.
+     */
+    function ensureForkEnvironment(): void
+    {
+        if (! extension_loaded('pcntl') || ! extension_loaded('posix')) {
+            test()->markTestSkipped('The pcntl and posix extensions are required to use the fork runtime.');
+        }
+
+        pokio()->useFork();
+    }
+}
+
+if (! function_exists('ensureSyncEnvironment')) {
+    /**
+     * Ensures the current environment is set to sync.
+     */
+    function ensureSyncEnvironment(): void
+    {
+        pokio()->useSync();
+    }
+}


### PR DESCRIPTION
This pull requests adds a set of basic scope isolation tests.
For some cases the expected behaviour between `fork`and `sync` can vary...

Please check, if everything works as expected 😉  