### PR TITLE
feat: Run async() calls immediately, rather than waiting for await()

### DIFF
--- a/src/Functions.php
+++ b/src/Functions.php
@@ -32,13 +32,7 @@ if (! function_exists('await')) {
     function await(array|Promise $promises): mixed
     {
         if (! is_array($promises)) {
-            $promises->defer();
-
             return $promises->resolve();
-        }
-
-        foreach ($promises as $promise) {
-            $promise->defer();
         }
 
         return array_map(

--- a/src/Promise.php
+++ b/src/Promise.php
@@ -30,15 +30,7 @@ final class Promise
      */
     public function __construct(private readonly Closure $callback)
     {
-        //
-    }
-
-    /**
-     * Defer the given callback to be executed asynchronously.
-     */
-    public function defer(): void
-    {
-        $this->future ??= Kernel::instance()->runtime()->defer($this->callback);
+        $this->defer();
     }
 
     /**
@@ -118,5 +110,13 @@ final class Promise
                 ($finally)();
             }
         });
+    }
+
+    /**
+     * Defer the given callback to be executed asynchronously.
+     */
+    private function defer(): void
+    {
+        $this->future = Kernel::instance()->runtime()->defer($this->callback);
     }
 }

--- a/tests/Unit/PromiseTest.php
+++ b/tests/Unit/PromiseTest.php
@@ -12,7 +12,6 @@ test('no catch for correct throwable type throws exception', function (): void {
             return true;
         });
 
-        $promise->defer();
         $promise->resolve();
     })->toThrow(RuntimeException::class, 'Uncaught exception');
 })->with('runtimes');
@@ -24,7 +23,6 @@ test('catch for correct throwable type handles exception', function (): void {
         return true;
     });
 
-    $promise->defer();
     $result = $promise->resolve();
     expect($result)->toBeTrue();
 })->with('runtimes');


### PR DESCRIPTION
This small change has the `async()` callback functions executing immediately rather than waiting to start with the `await()` call, this means that if there is any delay between when "queueing" the async function and the `await()` doesn't cause things to slow down. For example:

```php
$p1 = async(function (): string { sleep(3); return 'a'; });
$p2 = async(function (): string { sleep(1); return 'b'; });

sleep(2);

[$r2, $r2] = await([$p1, $p2]);
```

This will execute in ~3 seconds (first `async()` sleep time) rather than ~5 seconds (first `async()` + `sleep(2)`). `$p2` will finish _before_ the `sleep(2)` is complete (you can see this for yourself by dumping something to stdout).

I can see this being more important with nested async calls especially.

