### PR TITLE
[Test]: Add process termination tests

### DIFF
--- a/src/Runtime/Fork/ForkFuture.php
+++ b/src/Runtime/Fork/ForkFuture.php
@@ -21,7 +21,7 @@ final class ForkFuture implements Future
     /**
      * The result of the forked process, if any.
      *
-     * @var TResult
+     * @var TResult|null
      */
     private mixed $result = null;
 
@@ -44,7 +44,7 @@ final class ForkFuture implements Future
     /**
      * Awaits the result of the future.
      *
-     * @return TResult
+     * @return TResult|null
      */
     public function await(): mixed
     {

--- a/src/Runtime/Fork/ForkFuture.php
+++ b/src/Runtime/Fork/ForkFuture.php
@@ -54,6 +54,13 @@ final class ForkFuture implements Future
 
         pcntl_waitpid($this->pid, $status);
 
+        // Check if the IPC file exists and is non-empty
+        if (! file_exists($this->memory->path()) || filesize($this->memory->path()) === 0) {
+            $this->resolved = true;
+
+            return $this->result = null;
+        }
+
         $this->onWait->__invoke($this->pid);
 
         $this->resolved = true;

--- a/src/Runtime/Fork/IPC.php
+++ b/src/Runtime/Fork/IPC.php
@@ -107,6 +107,14 @@ final readonly class IPC
     }
 
     /**
+     * Returns the path to the IPC memory block.
+     */
+    public function path(): string
+    {
+        return $this->path;
+    }
+
+    /**
      * Loads libc and defines function bindings.
      */
     private static function libc(): FFI

--- a/tests/Feature/ProcessTerminationTest.php
+++ b/tests/Feature/ProcessTerminationTest.php
@@ -1,0 +1,38 @@
+<?php
+
+declare(strict_types=1);
+
+test('fork: die inside async closure terminates subprocess, not parent', function () {
+    ensureForkEnvironment();
+
+    $promise = async(function () {
+        exit('Goodbye!');
+    });
+
+    $result = await($promise);
+    expect($result)->toBeNull();
+});
+
+test('fork: exit inside async closure terminates subprocess, not parent', function () {
+    ensureForkEnvironment();
+
+    $promise = async(function () {
+        exit(42);
+    });
+
+    $result = await($promise);
+    expect($result)->toBeNull();
+});
+
+test('fork: async process gets killed, does not affect parent', function () {
+    ensureForkEnvironment();
+
+    $promise = async(function () {
+        posix_kill(posix_getpid(), SIGKILL);
+
+        return 'This will not be returned';
+    });
+
+    $result = await($promise);
+    expect($result)->toBeNull();
+});

--- a/tests/Pest.php
+++ b/tests/Pest.php
@@ -11,3 +11,28 @@ pest()->beforeEach(function (): void {
         default => null,
     };
 });
+
+if (! function_exists('ensureForkEnvironment')) {
+    /**
+     * Ensures the current environment is set to fork.
+     * Skips the test if the pcntl and posix extensions are not loaded.
+     */
+    function ensureForkEnvironment(): void
+    {
+        if (! extension_loaded('pcntl') || ! extension_loaded('posix')) {
+            test()->markTestSkipped('The pcntl and posix extensions are required to use the fork runtime.');
+        }
+
+        pokio()->useFork();
+    }
+}
+
+if (! function_exists('ensureSyncEnvironment')) {
+    /**
+     * Ensures the current environment is set to sync.
+     */
+    function ensureSyncEnvironment(): void
+    {
+        pokio()->useSync();
+    }
+}


### PR DESCRIPTION
## Description
Similar to #23 this pull requests adds a set of basic process termination tests.

For some cases the expected behaviour between fork and sync can vary... not sure if we should try to ensure both enviornments, work similarly

Please check, if everything works as expected 😉
