### PR TITLE
[Fix] Automatically defer promise in resolve()

### DIFF
--- a/src/Promise.php
+++ b/src/Promise.php
@@ -48,6 +48,8 @@ final class Promise
      */
     public function resolve(): mixed
     {
+        $this->defer();
+        
         return $this->future->await();
     }
 


### PR DESCRIPTION
### 🛠️ What’s Fixed

This PR updates the `Promise::resolve()` method to internally call `defer()` if the promise hasn't already been deferred. This makes the class more robust and avoids potential runtime errors caused by calling `resolve()` without deferring first.

### 📌 Why It Matters

Previously, users had to remember to call `$promise->defer()` manually before calling `$promise->resolve()`. If they forgot, it would result in an error due to `$this->future` being undefined.

By deferring automatically within `resolve()`, we:

- Prevent possible runtime exceptions.
- Improve developer experience.
- Make the API safer and easier to use.

### 💡 How It Works

The change leverages the existing null coalescing assignment (`??=`) in `defer()` to ensure it's only executed once, even if `defer()` is called multiple times.

```php
public function resolve(): mixed
{
    $this->defer();

    return $this->future->await();
}
