### PR TITLE
feat: add cancellation support for promises and futures

### DIFF
--- a/src/Contracts/Future.php
+++ b/src/Contracts/Future.php
@@ -17,4 +17,11 @@ interface Future
      * @return TResult
      */
     public function await(): mixed;
+
+    /**
+     * Cancels the asynchronous operation.
+     *
+     * @return bool Whether the operation was successfully cancelled
+     */
+    public function cancel(): bool;
 }

--- a/tests/Unit/PromiseTest.php
+++ b/tests/Unit/PromiseTest.php
@@ -28,3 +28,59 @@ test('catch for correct throwable type handles exception', function (): void {
     $result = $promise->resolve();
     expect($result)->toBeTrue();
 })->with('runtimes');
+
+test('can cancel a promise before it starts', function () {
+    $executed = false;
+    $promise = new Promise(function () use (&$executed) {
+        $executed = true;
+        return 'result';
+    });
+
+    expect($promise->cancel())->toBeTrue();
+    expect($executed)->toBeFalse();
+});
+
+test('can cancel a promise after it starts', function () {
+    $executed = false;
+    $promise = new Promise(function () use (&$executed) {
+        $executed = true;
+        return 'result';
+    });
+
+    $promise->defer();
+    expect($promise->cancel())->toBeTrue();
+    expect($executed)->toBeFalse();
+});
+
+test('cannot resolve a cancelled promise', function () {
+    $promise = new Promise(function () {
+        return 'result';
+    });
+
+    $promise->cancel();
+    expect(fn () => $promise->resolve())->toThrow(\RuntimeException::class);
+});
+
+test('cannot cancel a promise twice', function () {
+    $promise = new Promise(function () {
+        return 'result';
+    });
+
+    expect($promise->cancel())->toBeTrue();
+    expect($promise->cancel())->toBeFalse();
+});
+
+test('cancellation propagates through promise chain', function () {
+    $executed = false;
+    $promise = new Promise(function () use (&$executed) {
+        $executed = true;
+        return 'result';
+    });
+
+    $chainedPromise = $promise->then(function ($result) {
+        return $result . ' modified';
+    });
+
+    $chainedPromise->cancel();
+    expect($executed)->toBeFalse();
+});


### PR DESCRIPTION
- Introduced cancellation functionality in the Promise class, allowing promises to be cancelled before or after they start executing.
- Updated the Future interface to include a cancel method.
- Implemented cancellation logic in ForkFuture and SyncFuture classes, ensuring proper handling of cancelled states.
- Added unit tests to verify cancellation behavior for promises and futures.