### PR TITLE
Fix chained throwable types;

### DIFF
--- a/src/Support/Reflection.php
+++ b/src/Support/Reflection.php
@@ -7,6 +7,7 @@ namespace Pokio\Support;
 use Closure;
 use ReflectionFunction;
 use ReflectionNamedType;
+use ReflectionUnionType;
 use Throwable;
 
 /**
@@ -26,10 +27,13 @@ final readonly class Reflection
         $types = [];
 
         if (count($parameters) > 0) {
-            $type = $parameters[0]->getType();
+            $type = current($parameters)->getType();
 
-            /** @phpstan-ignore-next-line */
-            $types = is_array($type) ? $type : [$type];
+            $types = match (true) {
+                $type instanceof ReflectionUnionType => $type->getTypes(),
+                $type instanceof ReflectionNamedType => [$type],
+                default => [],
+            };
         }
 
         $matchesType = false;

--- a/tests/Unit/PromiseTest.php
+++ b/tests/Unit/PromiseTest.php
@@ -17,6 +17,31 @@ test('no catch for correct throwable type throws exception', function (): void {
     })->toThrow(RuntimeException::class, 'Uncaught exception');
 })->with('runtimes');
 
+test('Promise rethrows exception when catch block types do not match the thrown exception', function (): void {
+    expect(function () {
+        $promise = (new Promise(function (): void {
+            throw new RuntimeException('Uncaught exception');
+        }))->catch(function (InvalidArgumentException|LogicException $th): bool {
+            return true;
+        });
+
+        $promise->defer();
+        $promise->resolve();
+    })->toThrow(RuntimeException::class, 'Uncaught exception');
+})->with('runtimes');
+
+test('Promise catches exception when catch block types include the thrown exception', function (): void {
+    $promise = (new Promise(function (): void {
+        throw new RuntimeException('Uncaught exception');
+    }))->catch(function (InvalidArgumentException|LogicException|RuntimeException $th): bool {
+        return true;
+    });
+
+    $promise->defer();
+    $result = $promise->resolve();
+    expect($result)->toBeTrue();
+})->with('runtimes');
+
 test('catch for correct throwable type handles exception', function (): void {
     $promise = (new Promise(function (): void {
         throw new InvalidArgumentException('Caught exception');


### PR DESCRIPTION
### 🐛 Bug Reproduction

```php
require __DIR__.'/vendor/autoload.php';

$start = microtime(true);

$task1 = async(fn () => 1)
    ->then(function (int $result) {
        throw new RuntimeException('Error');
    })
    ->catch(function (InvalidArgumentException | LogicException $e) {
        dd($e);
    });

await($task1);

$end = microtime(true);
$executionTime = $end - $start;
```

Error: Call to undefined method ReflectionUnionType::getName() in /app/src/Support/Reflection.php:40
Stack trace:......

Proposed Fix:

Use ReflectionUnionType::getTypes() and handle it accordingly instead of calling getName() directly on a union type.