### PR TITLE
perf: add short sleep in ForkRuntime to reduce CPU busy-waiting

### DIFF
--- a/src/Runtime/Fork/ForkRuntime.php
+++ b/src/Runtime/Fork/ForkRuntime.php
@@ -56,6 +56,10 @@ final class ForkRuntime implements Runtime
     {
         while (count(self::$processes) >= $this->maxProcesses) {
             $this->waitForProcess();
+
+            // Adding a 1ms sleep prevents busy-waiting by yielding CPU time,
+            // reducing high CPU usage while waiting for a free process slot.
+            usleep(1000);
         }
 
         $ipc = IPC::create();


### PR DESCRIPTION
### Summary

This change introduces a small `usleep(1000)` (1 millisecond) delay inside the loop that waits for available process slots in `ForkRuntime::defer()`.

### Why this change is needed

When the number of active forked processes reaches the configured maximum, the current implementation continuously polls with `waitForProcess()` without any pause. This creates a busy-wait loop that can consume excessive CPU resources, leading to inefficient CPU usage and potentially degrading overall system performance.

### What this change does

- Adds a 1 millisecond sleep (`usleep(1000)`) inside the wait loop.
- This pause yields CPU time, allowing other processes to run instead of spinning continuously.
- The sleep duration is short enough to avoid noticeable delay in responsiveness while significantly reducing CPU load.

### Benefits

- Reduces high CPU usage caused by busy-waiting.
- Improves resource efficiency when waiting for child processes to finish.
- Maintains the asynchronous behavior and responsiveness of the runtime.

### Future considerations

- The sleep duration (currently 1000 microseconds) may be made configurable in the future to allow fine-tuning based on use case or environment.
