### PR TITLE
[API]: Add invokable function to promise

### DIFF
--- a/README.md
+++ b/README.md
@@ -169,7 +169,9 @@ var_dump(await([$promiseA, $promiseB])); // array(2) { [0]=> int(2) [1]=> int(4)
 Instead of using the await function, you can also invoke the promise directly, which will return the resolved value of the promise.
 
 ```php
-$result = async(fn (): int => 1 + 2)();
+$promise = async(fn (): int => 1 + 2);
+
+$result = $promise();
 
 var_dump($result); // int(3)
 ```

--- a/README.md
+++ b/README.md
@@ -166,6 +166,14 @@ $promiseB = async(function () {
 var_dump(await([$promiseA, $promiseB])); // array(2) { [0]=> int(2) [1]=> int(4) }
 ```
 
+Instead of using the await function, you can also invoke the promise directly, which will return the resolved value of the promise.
+
+```php
+$result = async(fn (): int => 1 + 2)();
+
+var_dump($result); // int(3)
+```
+
 ## Follow Nuno
 
 - Follow the creator Nuno Maduro:

--- a/src/Promise.php
+++ b/src/Promise.php
@@ -62,6 +62,16 @@ final class Promise
     }
 
     /**
+     * Invokes the promise, defering the callback to be executed immediately.
+     *
+     * @return TReturn
+     */
+    public function __invoke(): mixed
+    {
+        return $this->resolve();
+    }
+
+    /**
      * Defer the given callback to be executed asynchronously.
      */
     public function defer(): void

--- a/tests/Feature/PromiseTest.php
+++ b/tests/Feature/PromiseTest.php
@@ -191,3 +191,9 @@ test('promises are always waited for', function (): void {
 
     expect(file_get_contents($path))->toBe('start: a called by callback, a called by then, a called by finally.b called by callback, b called by then, b called by finally.c called by callback, c called by then, c called by finally.');
 })->with('runtimes');
+
+test('invokable promise resolves correctly', function (): void {
+    $result = async(fn (): int => 1 + 2)();
+
+    expect($result)->toBe(3);
+})->with('runtimes');


### PR DESCRIPTION
## Description
As mentioned by @ImSketch in #38 you can wrap a promise in an IIFE (Immediately Invoked Function Expression).
To allow for a similar syntax I added the __invokable method, which allows for a similar syntax:

```php
$result = async(fn (): int => 1 + 2)();

var_dump($result); // int(3)
```

## Related
- #38 