### PR TITLE
Remove duplicate defer call

### DIFF
--- a/src/Functions.php
+++ b/src/Functions.php
@@ -32,8 +32,6 @@ if (! function_exists('await')) {
     function await(array|Promise $promises): mixed
     {
         if (! is_array($promises)) {
-            $promises->defer();
-
             return $promises->resolve();
         }
 


### PR DESCRIPTION
## Description

In the `await` function we call the `->defer()` function first and then `->resolve()`
However the resolve function itself calls defer again!

For the single promise we can remove this duplicate call.
For the array, we might need this, to defer all promises at the same time before waiting on the first.