### PR TITLE
[Resolve]: Add option to run without waiting for the result

### DIFF
--- a/README.md
+++ b/README.md
@@ -176,6 +176,21 @@ $result = $promise();
 var_dump($result); // int(3)
 ```
 
+If the result of the promise is of no value to your application, you can use the await parameter to discard the result. This is useful when you just want to run a task asynchronously without caring about its result.
+
+```php
+$promise = async(function () {
+    sleep(2); // Or any other time-consuming task
+    
+    return 1 + 1;
+});
+
+$promise(await: false); // Discard the result
+echo "Task started, but main process continues...\n";
+```
+
+However, if your main process finishes before the asynchronous task completes, the parent process will wait for the child process to finish before exiting.
+
 ## Follow Nuno
 
 - Follow the creator Nuno Maduro:

--- a/src/Promise.php
+++ b/src/Promise.php
@@ -62,13 +62,14 @@ final class Promise
     }
 
     /**
-     * Invokes the promise, defering the callback to be executed immediately.
+     * Invokes the promise, deferring the callback to be executed immediately.
      *
-     * @return TReturn
+     * @param  bool  $await  Whether to await the result of the promise.
+     * @return ($await is true ? TReturn : null)
      */
-    public function __invoke(): mixed
+    public function __invoke(bool $await = true): mixed
     {
-        return $this->resolve();
+        return $this->resolve($await);
     }
 
     /**
@@ -82,15 +83,20 @@ final class Promise
     /**
      * Resolves the promise.
      *
-     * @return TReturn
+     * @param  bool  $await  Whether to await the result of the promise.
+     * @return ($await is true ? TReturn : null)
      */
-    public function resolve(): mixed
+    public function resolve(bool $await = true): mixed
     {
         $this->defer();
 
         assert($this->future instanceof Future);
 
-        return $this->future->await();
+        if ($await === true) {
+            return $this->future->await();
+        }
+
+        return null;
     }
 
     /**

--- a/tests/Feature/PromiseTest.php
+++ b/tests/Feature/PromiseTest.php
@@ -197,3 +197,27 @@ test('invokable promise resolves correctly', function (): void {
 
     expect($result)->toBe(3);
 })->with('runtimes');
+
+test('invokable waits for the promise to resolve', function (): void {
+    $promise = async(fn (): int => 1 + 2);
+
+    $result = $promise();
+
+    expect($result)->toBe(3);
+})->with('runtimes');
+
+test('invokable promise with await resolves correctly', function (): void {
+    $promise = async(fn (): int => 1 + 2);
+
+    $result = $promise(true);
+
+    expect($result)->toBe(3);
+})->with('runtimes');
+
+test('invokable promise without await does not resolve', function (): void {
+    $promise = async(fn (): int => 1 + 2);
+
+    $result = $promise(false);
+
+    expect($result)->toBeNull();
+})->with('runtimes');


### PR DESCRIPTION
## Description

This would allow for the user to run a promise async without waiting on the result.
Can be used for simply async task, that are not essential to the rest of the logic

```php
$promise = async(function () {
    sleep(2); // Or any other time-consuming task
    
    return 1 + 1;
});

$promise(await: false); // Discard the result
echo "Task started, but main process continues...\n";
```

## Related
- #38 