### PR TITLE
feat(channel): introduce unbuffered UNIX-socket channels

### DIFF
--- a/src/Channel/Channel.php
+++ b/src/Channel/Channel.php
@@ -1,0 +1,164 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Pokio\Channel;
+
+use RuntimeException;
+
+use function is_resource;
+
+/**
+ * Unbuffered, blocking channel implemented with a UNIX socket-pair.
+ */
+final class Channel
+{
+    /** @var resource|null */
+    private mixed $rx;
+
+    /** @var resource|null */
+    private mixed $tx;
+
+    public function __construct()
+    {
+        $pair = stream_socket_pair(STREAM_PF_UNIX, STREAM_SOCK_STREAM, 0);
+        if ($pair === false) {
+            throw new RuntimeException('Cannot create channel, failed to open stream');
+        }
+
+        /** @var array{0:resource,1:resource} $pair */
+        [$this->rx, $this->tx] = $pair;
+    }
+
+    public function __destruct()
+    {
+        $this->close();
+    }
+
+    /* ------------------------------------------------------------------ *
+     *  Static select()
+     * ------------------------------------------------------------------ */
+
+    /**
+     * Wait until at least one channel in $readable becomes ready.
+     *
+     * @param  list<self|ReadableChannel>  $readable
+     * @return int|null index of ready channel, or null on timeout
+     */
+    public static function select(array $readable, ?int $timeoutMs = null): ?int
+    {
+        /** @var list<resource> $streams */
+        $streams = [];
+        foreach ($readable as $ch) {
+            $stream = $ch instanceof self ? $ch->rx : $ch->stream();
+            if (! is_resource($stream)) {
+                throw new RuntimeException('closed channel passed to select()');
+            }
+            $streams[] = $stream;
+        }
+
+        $write = $except = null;
+        $sec = $timeoutMs === null ? null : intdiv($timeoutMs, 1000);
+        $usec = $timeoutMs === null ? null : ($timeoutMs % 1000) * 1000;
+
+        $ready = stream_select($streams, $write, $except, $sec, $usec);
+
+        if ($ready === false) {
+            throw new RuntimeException('stream_select() failed');
+        }
+        if ($ready === 0) {
+            return null;
+        }
+
+        /** @var int|false $idx */
+        $idx = array_search($streams[0], array_map(
+            static fn (self|ReadableChannel $c) => $c instanceof self ? $c->rx : $c->stream(),
+            $readable
+        ), true);
+
+        return $idx === false ? null : $idx;
+    }
+
+    /* ------------------------------------------------------------------ *
+     *  Send / Receive
+     * ------------------------------------------------------------------ */
+
+    public function send(mixed $msg): void
+    {
+        $this->assertOpen($this->tx);
+        /** @var resource $tx */ $tx = $this->tx;
+
+        $blob = serialize($msg);
+        $len = pack('N', mb_strlen($blob));
+
+        fwrite($tx, $len.$blob);
+    }
+
+    public function recv(): mixed
+    {
+        $this->assertOpen($this->rx);
+        /** @var resource $rx */ $rx = $this->rx;
+
+        $hdr = fread($rx, 4);
+        if ($hdr === '' || $hdr === false) {
+            throw new RuntimeException('channel closed');
+        }
+
+        $unpacked = unpack('Nlen', $hdr);
+        if ($unpacked === false) {
+            throw new RuntimeException('failed to unpack length header');
+        }
+
+        /** @var int $bytes */
+        $bytes = $unpacked['len'];
+        $blob = stream_get_contents($rx, $bytes);
+
+        if ($blob === false) {
+            throw new RuntimeException('failed to read channel payload');
+        }
+
+        /** @var mixed $value */
+        $value = unserialize($blob);
+
+        return $value;
+    }
+
+    /* ------------------------------------------------------------------ */
+
+    public function close(): void
+    {
+        if (is_resource($this->rx)) {
+            fclose($this->rx);
+        }
+        if (is_resource($this->tx)) {
+            fclose($this->tx);
+        }
+        $this->rx = $this->tx = null;
+    }
+
+    /**
+     * Return write-only and read-only “views” of the channel.
+     *
+     * @return array{WritableChannel, ReadableChannel}
+     */
+    public function split(): array
+    {
+        $this->assertOpen($this->tx);
+        $this->assertOpen($this->rx);
+
+        /** @var resource $tx */
+        $tx = $this->tx;
+        /** @var resource $rx */
+        $rx = $this->rx;
+
+        return [new WritableChannel($tx), new ReadableChannel($rx)];
+    }
+
+    /* ------------------------------------------------------------------ */
+    private function assertOpen(mixed $handle): void
+    {
+        if (! is_resource($handle)) {
+            throw new RuntimeException('channel closed');
+        }
+    }
+}

--- a/src/Channel/ReadableChannel.php
+++ b/src/Channel/ReadableChannel.php
@@ -1,0 +1,56 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Pokio\Channel;
+
+use RuntimeException;
+
+use function is_resource;
+
+final class ReadableChannel
+{
+    /** @param resource $rx */
+    public function __construct(private mixed $rx) {}
+
+    public function recv(): mixed
+    {
+        if (! is_resource($this->rx)) {
+            throw new RuntimeException('channel closed');
+        }
+
+        /** @var resource $rx */
+        $rx = $this->rx;
+
+        // ---- read 4-byte length header ------------------------------------
+        $hdr = fread($rx, 4);
+        if ($hdr === '' || $hdr === false) {
+            throw new RuntimeException('channel closed');
+        }
+
+        $unpacked = unpack('Nlen', $hdr);
+        if ($unpacked === false || ! isset($unpacked['len'])) {
+            throw new RuntimeException('invalid length header');
+        }
+
+        /** @var int $bytes */
+        $bytes = $unpacked['len'];
+
+        // ---- read payload --------------------------------------------------
+        $blob = stream_get_contents($rx, $bytes);
+        if ($blob === false) {
+            throw new RuntimeException('failed to read channel payload');
+        }
+
+        /** @var mixed $value */
+        $value = unserialize($blob);
+
+        return $value;
+    }
+
+    /** Expose raw stream for Channel::select(). @return resource */
+    public function stream(): mixed
+    {
+        return $this->rx;
+    }
+}

--- a/src/Channel/WritableChannel.php
+++ b/src/Channel/WritableChannel.php
@@ -1,0 +1,25 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Pokio\Channel;
+
+use RuntimeException;
+
+use function is_resource;
+
+final class WritableChannel
+{
+    /** @param resource $tx */
+    public function __construct(private mixed $tx) {}
+
+    public function send(mixed $msg): void
+    {
+        if (! is_resource($this->tx)) {
+            throw new RuntimeException('channel closed');
+        }
+        $blob = serialize($msg);
+        $len = pack('N', mb_strlen($blob));
+        fwrite($this->tx, $len.$blob);
+    }
+}

--- a/src/Functions.php
+++ b/src/Functions.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-use Pokio\Kernel;
+use Pokio\Channel\Channel;
 use Pokio\Pokio;
 use Pokio\Promise;
 
@@ -55,5 +55,15 @@ if (! function_exists('pokio')) {
     function pokio(): Pokio
     {
         return new Pokio;
+    }
+}
+
+if (! function_exists('chan')) {
+    /**
+     * Returns a Channel instance.
+     */
+    function chan(): Channel
+    {
+        return new Channel();
     }
 }

--- a/src/Kernel.php
+++ b/src/Kernel.php
@@ -49,13 +49,13 @@ final class Kernel
     /**
      * Specifies that pokio should use the fork as the async runtime.
      */
-    public function useFork(): void
+    public function useFork(?int $maxProcesses = null): void
     {
         if (Environment::supportsFork() === false) {
             throw new LogicException('Fork is not supported on this environment.');
         }
 
-        $this->asyncRuntime = new ForkRuntime(Environment::maxProcesses());
+        $this->asyncRuntime = new ForkRuntime($maxProcesses ?? Environment::maxProcesses());
     }
 
     /**

--- a/src/Runtime/Fork/ForkRuntime.php
+++ b/src/Runtime/Fork/ForkRuntime.php
@@ -98,7 +98,7 @@ final class ForkRuntime implements Runtime
 
         /** @var Future<TResult> $future */
         // @phpstan-ignore-next-line
-        $future = new ForkFuture($pid, $ipc, function (int $pid) {
+        $future = new ForkFuture($pid, $ipc, function (int $pid): void {
             unset(self::$processes[$pid]);
         });
 

--- a/tests/Feature/ChannelTest.php
+++ b/tests/Feature/ChannelTest.php
@@ -1,0 +1,43 @@
+<?php
+
+declare(strict_types=1);
+
+use Pokio\Channel\Channel;
+use Pokio\Exceptions\FutureAlreadyAwaited;
+use Pokio\Kernel;
+
+beforeAll(function (): void {
+    if (! extension_loaded('pcntl')) {
+        test()->markTestSkipped('pcntl extension missing');
+    }
+
+    Kernel::instance()->useFork(16);
+});
+
+test('single message crosses the channel via forked task', function (): void {
+    $ch = new Channel();
+
+    $tx = async(fn () => $ch->send('ping'));
+    $rx = async(fn () => $ch->recv());
+
+    [$void, $received] = await([$tx, $rx]);
+
+    expect($received)->toBe('ping');
+});
+
+test('awaiting a promise twice throws', function (): void {
+    $promise = async(fn () => 42);
+
+    expect(await($promise))->toBe(42)
+        ->and(fn () => await($promise))
+        ->toThrow(FutureAlreadyAwaited::class);
+
+});
+
+test('reading from a closed channel throws', function (): void {
+    $ch = new Channel();
+    $ch->close();
+
+    expect(fn () => $ch->recv())
+        ->toThrow(RuntimeException::class);
+});

--- a/tests/Feature/ProcessTerminationTest.php
+++ b/tests/Feature/ProcessTerminationTest.php
@@ -2,10 +2,10 @@
 
 declare(strict_types=1);
 
-test('fork: die inside async closure terminates subprocess, not parent', function () {
+test('fork: die inside async closure terminates subprocess, not parent', function (): void {
     ensureForkEnvironment();
 
-    $promise = async(function () {
+    $promise = async(function (): void {
         exit('Goodbye!');
     });
 
@@ -13,10 +13,10 @@ test('fork: die inside async closure terminates subprocess, not parent', functio
     expect($result)->toBeNull();
 });
 
-test('fork: exit inside async closure terminates subprocess, not parent', function () {
+test('fork: exit inside async closure terminates subprocess, not parent', function (): void {
     ensureForkEnvironment();
 
-    $promise = async(function () {
+    $promise = async(function (): void {
         exit(42);
     });
 
@@ -24,7 +24,7 @@ test('fork: exit inside async closure terminates subprocess, not parent', functi
     expect($result)->toBeNull();
 });
 
-test('fork: async process gets killed, does not affect parent', function () {
+test('fork: async process gets killed, does not affect parent', function (): void {
     ensureForkEnvironment();
 
     $promise = async(function () {

--- a/tests/Feature/PromiseTest.php
+++ b/tests/Feature/PromiseTest.php
@@ -97,7 +97,7 @@ test('async with a finally callback', function (): void {
 test('finally is called after exception', function (): void {
     $path = tempnam(sys_get_temp_dir(), 'pokio_');
 
-    $promise = async(function () {
+    $promise = async(function (): void {
         throw new RuntimeException('Exception 1');
     })->finally(function () use (&$path): void {
         file_put_contents($path, 'called');
@@ -175,12 +175,12 @@ test('promises are always waited for', function (): void {
         file_put_contents($path, 'b called by finally.', FILE_APPEND);
     });
 
-    async(function () use (&$path) {
+    async(function () use (&$path): void {
         async(fn () => file_put_contents($path, 'c called by callback, ', FILE_APPEND));
-    })->then(function () use (&$path) {
+    })->then(function () use (&$path): void {
         // append to the file
         async(fn () => file_put_contents($path, 'c called by then, ', FILE_APPEND));
-    })->finally(function () use (&$path) {
+    })->finally(function () use (&$path): void {
         // append to the file
         async(fn () => file_put_contents($path, 'c called by finally.', FILE_APPEND));
     });

--- a/tests/Feature/ScopeIsolationTest.php
+++ b/tests/Feature/ScopeIsolationTest.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-test('sync: global variables do leak into closure scope', function () {
+test('sync: global variables do leak into closure scope', function (): void {
     ensureSyncEnvironment();
 
     global $leakyGlobal;
@@ -12,7 +12,7 @@ test('sync: global variables do leak into closure scope', function () {
     expect(await($promise))->toBeTrue();
 });
 
-test('sync: closure variables using `use` do leak outside', function () {
+test('sync: closure variables using `use` do leak outside', function (): void {
     ensureSyncEnvironment();
 
     $value = 'normal';
@@ -25,7 +25,7 @@ test('sync: closure variables using `use` do leak outside', function () {
         ->and($value)->toBe('secret');
 });
 
-test('sync: constants are available inside closures', function () {
+test('sync: constants are available inside closures', function (): void {
     ensureSyncEnvironment();
 
     define('SYNC_SCOPE_TEST_CONST', 'yes');
@@ -34,7 +34,7 @@ test('sync: constants are available inside closures', function () {
     expect($result)->toBe('yes');
 });
 
-test('sync: external variables are visible without `use`', function () {
+test('sync: external variables are visible without `use`', function (): void {
     ensureSyncEnvironment();
 
     $secret = 'nope';
@@ -60,7 +60,7 @@ test('sync: callback does not persist GLOBALS in sync env', function (): void {
         ->and($GLOBALS['test'])->toBe(2);
 });
 
-test('fork: global variables do leak into closure scope', function () {
+test('fork: global variables do leak into closure scope', function (): void {
     ensureForkEnvironment();
 
     global $leakyGlobal;
@@ -70,7 +70,7 @@ test('fork: global variables do leak into closure scope', function () {
     expect(await($promise))->toBeTrue();
 });
 
-test('fork: closure variables using `use` do not leak outside', function () {
+test('fork: closure variables using `use` do not leak outside', function (): void {
     ensureForkEnvironment();
 
     $value = 'normal';
@@ -84,7 +84,7 @@ test('fork: closure variables using `use` do not leak outside', function () {
         ->and($value)->toBe('normal');
 });
 
-test('fork: constants are available inside closures', function () {
+test('fork: constants are available inside closures', function (): void {
     ensureForkEnvironment();
 
     define('FORK_SCOPE_TEST_CONST', 'yes');
@@ -93,7 +93,7 @@ test('fork: constants are available inside closures', function () {
     expect($result)->toBe('yes');
 });
 
-test('fork: external variables are visible without `use`', function () {
+test('fork: external variables are visible without `use`', function (): void {
     ensureForkEnvironment();
 
     $secret = 'nope';

--- a/tests/Unit/ChannelTest.php
+++ b/tests/Unit/ChannelTest.php
@@ -1,0 +1,35 @@
+<?php
+
+declare(strict_types=1);
+
+use Pokio\Channel\Channel;
+
+it('sends and receives FIFO', function (): void {
+    $c = new Channel();
+    foreach (['a', 'b', 'c'] as $v) {
+        $c->send($v);
+    }
+    foreach (['a', 'b', 'c'] as $v) {
+        expect($c->recv())->toBe($v);
+    }
+});
+
+it('split() returns independent ends', function (): void {
+    [$tx, $rx] = (new Channel())->split();
+    $tx->send(123);
+    expect($rx->recv())->toBe(123);
+});
+
+it('select() picks ready channel', function (): void {
+    $c1 = new Channel();
+    $c2 = new Channel();
+    $c1->send('X');
+    $idx = Channel::select([$c1, $c2], 100);
+    expect($idx)->toBe(0);
+});
+
+it('throws after close', function (): void {
+    $c = new Channel();
+    $c->close();
+    expect(fn () => $c->recv())->toThrow(RuntimeException::class);
+});

--- a/tests/Unit/PromiseTest.php
+++ b/tests/Unit/PromiseTest.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 use Pokio\Promise;
 
 test('no catch for correct throwable type throws exception', function (): void {
-    expect(function () {
+    expect(function (): void {
         $promise = (new Promise(function (): void {
             throw new RuntimeException('Uncaught exception');
         }))->catch(function (InvalidArgumentException $th): bool {
@@ -18,7 +18,7 @@ test('no catch for correct throwable type throws exception', function (): void {
 })->with('runtimes');
 
 test('Promise rethrows exception when catch block types do not match the thrown exception', function (): void {
-    expect(function () {
+    expect(function (): void {
         $promise = (new Promise(function (): void {
             throw new RuntimeException('Uncaught exception');
         }))->catch(function (InvalidArgumentException|LogicException $th): bool {

--- a/tests/Unit/ReadableChannelTest.php
+++ b/tests/Unit/ReadableChannelTest.php
@@ -1,0 +1,41 @@
+<?php
+
+declare(strict_types=1);
+
+use Pokio\Channel\Channel;
+use Pokio\Channel\ReadableChannel;
+use Pokio\Channel\WritableChannel;
+
+/**
+ * @return array{WritableChannel, ReadableChannel}
+ */
+function readablePair(): array
+{
+    return (new Channel())->split();
+}
+
+it('reads a message sent by its write end', function (): void {
+    [$tx, $rx] = readablePair();
+
+    $tx->send(42);
+
+    expect($rx->recv())->toBe(42);
+});
+
+it('ReadableChannel has no send method', function (): void {
+    [, $rx] = readablePair();
+
+    expect(fn () => $rx->send('oops'))->toThrow(Error::class);
+});
+
+it('throws when reading from a closed channel', function (): void {
+    [$tx, $rx] = readablePair();
+    $tx->send('baz');
+
+    $chan = new Channel();
+    [, $rx2] = $chan->split();
+    $chan->close();
+
+    expect(fn () => $rx2->recv())
+        ->toThrow(RuntimeException::class);
+});

--- a/tests/Unit/WritabbleChannelTest.php
+++ b/tests/Unit/WritabbleChannelTest.php
@@ -1,0 +1,47 @@
+<?php
+
+declare(strict_types=1);
+use Pokio\Channel\Channel;
+use Pokio\Channel\ReadableChannel;
+use Pokio\Channel\WritableChannel;
+
+/**
+ * @return array{WritableChannel, ReadableChannel}
+ */
+function writablePair(): array
+{
+    return (new Channel())->split();
+}
+
+it('writes a message that can be received by its read end', function (): void {
+    [$tx, $rx] = writablePair();
+
+    $tx->send('foo');
+
+    expect($rx->recv())->toBe('foo');
+});
+
+it('WritableChannel has no recv method', function (): void {
+    [$tx] = writablePair();
+
+    expect(fn () => $tx->recv())->toThrow(Error::class);
+});
+
+it(/**
+ * @throws ReflectionException
+ */ 'throws when sending on a closed channel', closure: function (): void {
+    [$tx, $rx] = writablePair();
+    $rx->recv();
+
+    /** @var Channel $base */
+    $base = (new ReflectionClass($tx))
+        ->getConstructor()?->getParameters()[0]?->getDeclaringClass()
+        ?: null;
+
+    $chan = new Channel();
+    [$tx2] = $chan->split();
+    $chan->close();
+
+    expect(fn () => $tx2->send('bar'))
+        ->toThrow(RuntimeException::class);
+});


### PR DESCRIPTION
<!--
- Fill in the form below correctly. This will help the Peck team to understand the PR and also work on it.
-->

### What:

- [ ] Bug Fix  
- [x] New Feature

### Description:

This PR introduces **inter-process communication channels** to Pokio:

* **`Pokio\Channel\Channel`** – unbuffered UNIX-socket channel with
  `send()` / `recv()` and automatic resource cleanup.  
* **`WritableChannel`** & **`ReadableChannel`** – read- / write-only views
  returned by `Channel::split()` ideal for handing the correct end to
  forked tasks.  
* **`Channel::select()`** – lightweight helper for multiplexing reads
  across multiple channels with an optional timeout.

**EXAMPLES**

1) Single producer → single consumer

```php
$ch   = chan();                             
$send = async(fn () => $ch->send('hello'));  
$recv = async(fn () => $ch->recv());

$results = await([$send, $recv]);

printf("Received: %s\n", $results[1]);   
``` 

```php

$ch = chan();
// WritableChannel + ReadableChannel
[$tx, $rx] = $ch->split();

/*
|----------------------------------------------------------
| Spawn N producers, each with its own message.
|----------------------------------------------------------
*/
$producers = [];
foreach (['red', 'green', 'blue'] as $color) {
    $producers[] = async(fn () => $tx->send($color));
}

/*
|----------------------------------------------------------
| Single consumer: multiplex reads so we don’t block on one
| channel while others have data.
|----------------------------------------------------------
*/
$consumer = async(function () use ($rx) {
    $messages = [];

    for ($i = 0; $i < 3; $i++) {
        Channel::select([$rx]);        
        $messages[] = $rx->recv();
    }

    return $messages;
});

$results = await([...$producers, $consumer]);

print_r(end($results));

```

