### PR TITLE
Disable fork when xdebug debug mode is active

### DIFF
--- a/peck.json
+++ b/peck.json
@@ -21,7 +21,11 @@
             "unschedule",
             "unschedules",
             "defering",
-            "unserializes"
+            "unserializes",
+            "xdebug",
+            "xdebug's",
+            "ini",
+            "yml"
         ],
         "paths": []
     }

--- a/src/Environment.php
+++ b/src/Environment.php
@@ -53,9 +53,39 @@ final class Environment
      */
     public static function supportsFork(): bool
     {
+        if (self::hasXdebugDebugMode()) {
+            return false;
+        }
+
         return extension_loaded('pcntl')
             && extension_loaded('posix')
             && class_exists('FFI');
+    }
+
+    /**
+     * Whether xdebug debug mode is enabled.
+     *
+     * Xdebug's debug mode maintains socket connections that are inherited
+     * by forked child processes, causing them to crash silently. Other
+     * modes (develop, trace, profile, coverage) do not establish external
+     * connections and are safe for forking.
+     *
+     * Checks the XDEBUG_MODE environment variable first, which takes
+     * precedence over the xdebug.mode INI setting.
+     */
+    private static function hasXdebugDebugMode(): bool
+    {
+        if (! extension_loaded('xdebug')) {
+            return false;
+        }
+
+        $mode = getenv('XDEBUG_MODE');
+
+        if ($mode === false) {
+            $mode = (string) ini_get('xdebug.mode');
+        }
+
+        return str_contains($mode, 'debug');
     }
 
     /**

--- a/tests/Datasets.php
+++ b/tests/Datasets.php
@@ -2,11 +2,13 @@
 
 declare(strict_types=1);
 
+use Pokio\Environment;
+
 dataset('runtimes', [
     'sync' => fn () => pokio()->useSync(),
     'fork' => function (): void {
-        if (! extension_loaded('pcntl') || ! extension_loaded('posix')) {
-            $this->markTestSkipped('The pcntl and posix extensions are required to use the fork runtime.');
+        if (! Environment::supportsFork()) {
+            $this->markTestSkipped('Fork is not supported in this environment.');
         }
 
         pokio()->useFork();

--- a/tests/Pest.php
+++ b/tests/Pest.php
@@ -15,12 +15,12 @@ pest()->beforeEach(function (): void {
 if (! function_exists('ensureForkEnvironment')) {
     /**
      * Ensures the current environment is set to fork.
-     * Skips the test if the pcntl and posix extensions are not loaded.
+     * Skips the test if the environment does not support forking.
      */
     function ensureForkEnvironment(): void
     {
-        if (! extension_loaded('pcntl') || ! extension_loaded('posix')) {
-            test()->markTestSkipped('The pcntl and posix extensions are required to use the fork runtime.');
+        if (! Environment::supportsFork()) {
+            test()->markTestSkipped('Fork is not supported in this environment.');
         }
 
         pokio()->useFork();

--- a/tests/Unit/EnvironmentTest.php
+++ b/tests/Unit/EnvironmentTest.php
@@ -39,3 +39,36 @@ test('environment get total memory for unsupported os', function (): void {
     expect(fn () => $reflectionMethod->invokeArgs(null, ['UnsupportedOS']))
         ->toThrow(RuntimeException::class, 'Unsupported OS: UnsupportedOS');
 });
+
+test('hasXdebugDebugMode returns true when xdebug debug mode is enabled', function (): void {
+    $reflection = new ReflectionClass(Environment::class);
+    $method = $reflection->getMethod('hasXdebugDebugMode');
+
+    $result = $method->invoke(null);
+
+    $mode = getenv('XDEBUG_MODE');
+
+    if ($mode === false) {
+        $mode = (string) ini_get('xdebug.mode');
+    }
+
+    $expectedActive = str_contains($mode, 'debug');
+
+    expect($result)->toBe($expectedActive);
+})->skip(fn () => ! extension_loaded('xdebug'), 'Xdebug must be loaded');
+
+test('supportsFork returns false when xdebug debug mode is enabled', function (): void {
+    expect(Environment::supportsFork())->toBeFalse();
+})->skip(function (): bool {
+    if (! extension_loaded('xdebug')) {
+        return true;
+    }
+
+    $mode = getenv('XDEBUG_MODE');
+
+    if ($mode === false) {
+        $mode = (string) ini_get('xdebug.mode');
+    }
+
+    return ! str_contains($mode, 'debug');
+});


### PR DESCRIPTION
### What:

- [x] Bug Fix
- [ ] New Feature

### Description:

When xdebug is loaded with debug mode enabled (`debug`, `develop,debug`, etc.), forked child processes crash silently due to inherited debug socket connections. This causes `await()` to return `null` instead of the closure's result.

The issue is a **non-deterministic race condition** — the number of null results varies between runs, and it only triggers when forked processes run long enough (e.g., cold PHPStan cache during Pest type coverage analysis).

**Evidence** (tested with 88 PHP files, clearing PHPStan cache each run):

| Run | Null results from `await()` |
|-----|----------------------------|
| 1   | 1                          |
| 2   | 2                          |
| 3   | 3                          |
| 4   | 2                          |
| 5   | 3                          |

With `php -dxdebug.mode=off` — zero null results across all runs.

**Changes:**
- `Environment::supportsFork()` now checks for xdebug debug mode via a new `isXdebugActive()` method. Only `debug` mode is blocked — other modes (develop, coverage, trace, profile) don't establish external connections and remain safe for forking
- Test helpers (`ensureForkEnvironment()` and the `runtimes` dataset) now use `supportsFork()` instead of manual extension checks, so fork tests are properly skipped when the environment does not support forking

### Related:

- https://github.com/nunomaduro/pokio/issues/48
- https://github.com/pestphp/pest/issues/1666